### PR TITLE
Improve install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,32 @@
+#!/bin/sh
+
+if ! pkg-config cglm; then
+echo "cglm not found on the system"
+echo "building cglm"
 git clone https://github.com/recp/cglm
 cd cglm
 mkdir build
 cd build
 cmake ..
-make
+make -j$(nproc)
 sudo make install
 cd ../../
 rm -rf cglm
+fi
+
+if ! pkg-config libclipboard; then
+echo "libclipboard not found on the system"
+echo "building libclipboard"
 git clone https://github.com/jtanx/libclipboard
 cd libclipboard
 cmake .
-make -j4
+make -j$(nproc)
 sudo make install
 cd ..
 rm -rf libclipboard
-make && sudo make install
+fi
+
+make -j$(nproc) && sudo make install
 echo "====================="
 echo "INSTALLATION FINISHED"
 echo "====================="


### PR DESCRIPTION
I just improved a bit the install script
Now, it check if libs (cglm and libclipboard) are already on the system before building them
I also use `nproc` to use the correct number of thread during compilation instead of hardcoding it or compiling on a single thread