### PR TITLE
Check for correct OpenGL version in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+get_opengl_version() {
+  glxinfo | grep "OpenGL version string" | awk '{print $4}'
+}
+
+REQUIRED_VERSION="4.5"
+CURRENT_VERSION=$(get_opengl_version)
+
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+  echo "Your OpenGL version is $CURRENT_VERSION. OpenGL version $REQUIRED_VERSION or higher is required."
+  echo "Please update your OpenGL drivers."
+  exit 1
+fi
+
+echo "OpenGL $CURRENT_VERSION is sufficient."
+
 if ! pkg-config cglm; then
 echo "cglm not found on the system"
 echo "building cglm"


### PR DESCRIPTION
I found the todo tutorial yesterday on YouTube and I was excited to try it out! However, after adding leif and compiling, the program would segfault. I spent the last day checking everywhere for an answer, and found that a call in leif's `renderer_init()` function, specifically `glCreateVertexArrays`, is only available in OpenGL version 4.5 and higher.

Admittedly, it's a little obvious of an answer, but I had zero indication that this was the problem's source. I've added a little OpenGL version checker to the `install.sh` script to make this problem a little easier for anyone who might want to use leif, but I'll leave it to you if you want to include it or not!

Thanks for all the hard work, I'm able to follow along the video now and I really like what you've made.