### PR TITLE
Fixed: crash because X key handler didn't have !lf_key_is_down(GLFW_K…

### DIFF
--- a/include/leif/leif.h
+++ b/include/leif/leif.h
@@ -50,6 +50,7 @@ typedef struct {
     uint32_t id;
     uint32_t width, height;
 } LfTexture;
+
 typedef struct {
     void* cdata;
     void* font_info;

--- a/leif.c
+++ b/leif.c
@@ -973,6 +973,7 @@ void input_field(LfInputField* input, InputFieldType type, const char* file, int
 
         }
         case GLFW_KEY_X: {
+          if (!lf_key_is_down(GLFW_KEY_LEFT_CONTROL)) break;
           char selection[strlen(input->buf)];
           memset(selection, 0, strlen(input->buf));
           substr_str(input->buf, input->selection_start, input->selection_end, selection);


### PR DESCRIPTION
This pull request addresses an issue where the input field crashes due to missing control key checks when the X key is pressed. 

Changes include:
- Adding a check to ensure the control key is held down before performing the cut operation with GLFW_KEY_X.
- Minor code cleanup for readability.

These changes prevent accidental cut operations and ensure stability of the input field.

Please review the changes and merge if everything looks good. Thanks!